### PR TITLE
fix return value checking from s_readline in parse_line

### DIFF
--- a/src/lem_parse_line.c
+++ b/src/lem_parse_line.c
@@ -28,7 +28,7 @@ int	lem_parse_line(
 
 	line = NULL;
 	ret = s_readline(0, &line);
-	if (ret != 1)
+	if (!ret)
 		return (ret);
 	if (*type == ROOM_SRC || *type == ROOM_SINK)
 		ret = lem_parse_room(graph, line, type);


### PR DESCRIPTION
I noticed and fixed a bug in input parsing while testing test_maps maps for leaks.

For the following map ("direct")
```
1
##start
1 2 3
##end
4 5 6
1-4
```
that does not contain a newline after the link, previous input parsing only checked ``s_readline`` return value for whether it is 1. If not 1, it would not parse the line but return with a positive return value (that was not registered as an error). Consequently, the resulting graph lacked the edge ``1-4``, leading to an error in graph processing.