### PR TITLE
add lem_exit_error, modify error handling on malloc errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ CORE = $(CORE_DIR)/libcore.a
 
 SRC = $(addprefix src/, \
 	main.c \
+	lem_exit_error.c \
 	lem_parse_input.c \
 	lem_parse_line.c \
 	lem_parse_room.c \
@@ -32,13 +33,14 @@ SRC = $(addprefix src/, \
 	lem_print_path_combinations.c \
 	lem_print_path.c \
 	lem_print_string.c \
+	lem_print_result.c \
 )
 
 OBJ = $(subst $(SRC_DIR), $(OBJ_DIR), $(SRC:.c=.o))
 
 CC = gcc
 #CFLAGS = -g -Wall -Wextra -Werror #-fsanitize=address
-CFLAGS = -O3 -Wall -Wextra -Werror -Wpedantic -Wtype-limits -Wunused \
+CFLAGS = -Wall -Wextra -Werror -Wpedantic -Wtype-limits -Wunused \
                 -Wunreachable-code -Wshadow -fPIC -Wconversion
 CPPFLAGS = -I . -I include -I core
 LDLIBS = -lcore #-lm -lpthread

--- a/include/lem_in.h
+++ b/include/lem_in.h
@@ -52,6 +52,8 @@ typedef struct s_lem
 
 typedef t_array	t_paths;
 
+void			lem_exit_error(char *msg);
+
 t_lem			lem_init_data(void);
 t_edge_attr		*lem_init_edge_attr(int capacity);
 t_node_attr		*lem_init_node_attr(char *name,
@@ -67,7 +69,7 @@ int				a_to_i(const char *str);
 
 int				lem_process_graph(t_parray *output, t_lem *data);
 t_lem			lem_transform_vertex_disjoint(t_lem *data);
-t_parray		*lem_find_max_flow_paths(t_lem *lem);
+t_parray		lem_find_max_flow_paths(t_lem *lem);
 t_parray		*lem_save_max_flow_paths(t_graph_node *s, t_graph_node *t,
 					size_t max_flow);
 
@@ -77,9 +79,9 @@ ssize_t			lem_edge_remaining_capacity(t_graph_edge *edge);
 void			lem_free_graph(t_graph *graph);
 void			lem_free_path_combinations(t_parray *path_combinations);
 
-int				*lem_optimise_path_use(t_parray **paths_to_use,
+void			lem_optimise_path_use(int *ants_per_path, t_parray **paths_to_use,
 					t_parray *path_combinations, size_t ants);
-int				lem_move_ants(t_lem *data, t_parray *paths,
+void			lem_move_ants(t_lem *data, t_parray *paths,
 					int *ants_per_path, t_parray *output);
 
 ssize_t			lem_print_node(void *data, size_t i);
@@ -88,5 +90,6 @@ ssize_t			lem_print_string(void *data, size_t i);
 ssize_t			lem_print_path(void *data, size_t i);
 ssize_t			lem_print_path_combinations(void *data, size_t i);
 void			lem_print_ants_per_path(int *ants_per_path, t_parray *paths);
+void			lem_print_result(t_parray *input, t_parray *output);
 
 #endif

--- a/src/lem_exit_error.c
+++ b/src/lem_exit_error.c
@@ -1,0 +1,7 @@
+#include "lem_in.h"
+
+void	lem_exit_error(char *msg)
+{
+	print_fd(2, "%s\n", msg);
+	exit(1);
+}

--- a/src/lem_free_path_combinations.c
+++ b/src/lem_free_path_combinations.c
@@ -6,6 +6,7 @@ static ssize_t	free_path(void *data, size_t i)
 
 	path = data;
 	parr_free(path);
+	free(path);
 	return ((ssize_t)i);
 }
 
@@ -16,6 +17,7 @@ static ssize_t	free_paths(void *data, size_t i)
 	paths = data;
 	parr_iter(paths, free_path);
 	parr_free(paths);
+	free(paths);
 	return ((ssize_t)i);
 }
 

--- a/src/lem_move_ants.c
+++ b/src/lem_move_ants.c
@@ -8,11 +8,10 @@ static void	move_to_line(char **line, int ant, const char *node_key)
 
 	move = format("L%d-%s ", ant, node_key);
 	if (move == NULL)
-	{
-		free(*line);
-		*line = NULL;
-	}
+		lem_exit_error("ERROR");
 	new = s_join(*line, move);
+	if (new == NULL)
+		lem_exit_error("ERROR");
 	free(move);
 	free(*line);
 	*line = new;
@@ -49,15 +48,13 @@ static int	move_ants_in_path(t_parray *path,
 			else
 				move_ant(prev->attr, node->attr, ants, 0);
 			move_to_line(line, ((t_node_attr *)node->attr)->value, node->key);
-			if (*line == NULL)
-				return (-1);
 		}
 		j++;
 	}
 	return (ants_per_path);
 }
 
-int	save_round_to_line(char **line, t_parray *paths,
+void	save_round_to_line(char **line, t_parray *paths,
 	int *ants_per_path, size_t ants)
 {
 	t_parray	*path;
@@ -69,14 +66,11 @@ int	save_round_to_line(char **line, t_parray *paths,
 		path = parr_get(paths, i);
 		ants_per_path[i] = move_ants_in_path(path, line,
 				ants_per_path[i], ants);
-		if (ants_per_path[i] == -1)
-			return (-1);
 		i++;
 	}
-	return (1);
 }
 
-int	lem_move_ants(t_lem *data, t_parray *paths, int *ants_per_path,
+void	lem_move_ants(t_lem *data, t_parray *paths, int *ants_per_path,
 	t_parray *output)
 {
 	t_graph_node	*source;
@@ -87,15 +81,10 @@ int	lem_move_ants(t_lem *data, t_parray *paths, int *ants_per_path,
 	while (1)
 	{
 		line = NULL;
-		if (!save_round_to_line(&line, paths, ants_per_path, data->ant_count))
-			return (-1);
+		save_round_to_line(&line, paths, ants_per_path, data->ant_count);
 		if (line == NULL)
 			break ;
-		if (!parr_add_last(output, line))
-		{
-			free(line);
-			return (-1);
-		}
+		if (parr_add_last(output, line) != 1)
+			lem_exit_error("ERROR");
 	}
-	return (1);
 }

--- a/src/lem_optimise_path_use.c
+++ b/src/lem_optimise_path_use.c
@@ -80,21 +80,18 @@ static size_t	optimise_i_paths(t_parray *path_combinations,
 	return (path_cost);
 }
 
-int	*lem_optimise_path_use(
+void	lem_optimise_path_use(
+	int		*ants_per_path,
 	t_parray **paths_to_use,
 	t_parray *path_combinations,
 	size_t ants)
 {
-	int		*ants_per_path;
 	size_t	max_flow;
 	size_t	i;
 	size_t	min_path_cost;
 	size_t	path_cost;
 
 	max_flow = path_combinations->len;
-	ants_per_path = (int *)malloc(sizeof(int) * max_flow);
-	if (ants_per_path == NULL)
-		return (NULL);
 	min_path_cost = (size_t)-1;
 	i = 0;
 	while (i < max_flow)
@@ -108,5 +105,4 @@ int	*lem_optimise_path_use(
 	}
 	*paths_to_use = parr_get(path_combinations, i - 1);
 	optimise_i_paths(path_combinations, i - 1, ants_per_path, ants);
-	return (ants_per_path);
 }

--- a/src/lem_parse_line.c
+++ b/src/lem_parse_line.c
@@ -37,7 +37,7 @@ int	lem_parse_line(t_lem *data, t_parray *input, enum e_line_type *type)
 		ret = lem_parse_link(data, line);
 	else
 		ret = lem_parse_room(data, line, type);
-	if (ret == -1 || !parr_add_last(input, line))
+	if (ret == -1 || parr_add_last(input, line) != 1)
 	{
 		free(line);
 		return (-1);

--- a/src/lem_parse_room.c
+++ b/src/lem_parse_room.c
@@ -46,10 +46,12 @@ int	lem_parse_room(t_lem *data, char *line, enum e_line_type *type)
 	if (!validate_coordinates(ptr + 1, &coordinates))
 		return (-1);
 	attr = lem_init_node_attr(line, coordinates, NULL);
-	if (attr == NULL)
+	if (!attr || graph_add_node(&data->graph, attr->name, attr) != 1)
+	{
+		free(attr->name);
+		free(attr);
 		return (-1);
-	if (graph_add_node(&data->graph, attr->name, attr) == -1)
-		return (-1);
+	}
 	*ptr = ' ';
 	if (*type == ROOM_SRC || *type == ROOM_SINK)
 		update_lem_data(data, attr->name, *type);

--- a/src/lem_print_result.c
+++ b/src/lem_print_result.c
@@ -1,0 +1,8 @@
+#include "lem_in.h"
+
+void	lem_print_result(t_parray *input, t_parray *output)
+{
+	parr_iter(input, lem_print_string);
+	print("\n");
+	parr_iter(output, lem_print_string);
+}

--- a/src/lem_process_graph.c
+++ b/src/lem_process_graph.c
@@ -3,27 +3,26 @@
 int	lem_process_graph(t_parray *output, t_lem *data)
 {
 	t_lem		transformed_data;
-	t_parray	*path_combinations;
+	t_parray	path_combinations;
 	t_parray	*paths_to_use;
 	int			*ants_per_path;
 
 	transformed_data = lem_transform_vertex_disjoint(data);
-	if (graph_null(&transformed_data.graph))
-		return (-1);
 	path_combinations = lem_find_max_flow_paths(&transformed_data);
 	lem_free_graph(&transformed_data.graph);
-	if (path_combinations == NULL)
+	if (parr_null(&path_combinations))
 		return (-1);
 	if (PRINT_DEBUG)
-		parr_iter(path_combinations, lem_print_path_combinations);
-	ants_per_path = lem_optimise_path_use(&paths_to_use,
-			path_combinations, data->ant_count);
+		parr_iter(&path_combinations, lem_print_path_combinations);
+	ants_per_path = (int *)malloc(sizeof(int) * path_combinations.len);
+	if (!ants_per_path)
+		lem_exit_error("ERROR");
+	lem_optimise_path_use(ants_per_path, &paths_to_use,
+		&path_combinations, data->ant_count);
 	if (PRINT_DEBUG)
-		parr_iter(paths_to_use, lem_print_path);
-	if (PRINT_DEBUG)
-		lem_print_ants_per_path(ants_per_path, path_combinations);
+		lem_print_ants_per_path(ants_per_path, &path_combinations);
 	lem_move_ants(data, paths_to_use, ants_per_path, output);
 	free(ants_per_path);
-	lem_free_path_combinations(path_combinations);
+	lem_free_path_combinations(&path_combinations);
 	return (1);
 }

--- a/src/lem_save_max_flow_paths.c
+++ b/src/lem_save_max_flow_paths.c
@@ -9,7 +9,7 @@ void	save_flow_path(t_parray *path, t_graph_node *src, t_graph_node *dst)
 
 	node = src;
 	parr_add_last(path, ((t_node_attr *)node->attr)->org);
-	add_every_other = 0;
+	add_every_other = 1;
 	while (strcmp(node->key, dst->key) != 0)
 	{
 		i = 0;
@@ -17,19 +17,19 @@ void	save_flow_path(t_parray *path, t_graph_node *src, t_graph_node *dst)
 		{
 			edge = parr_get(&node->in, i);
 			if (((t_edge_attr *)edge->attr)->flow > 0)
-			{
-				add_every_other++;
-				if (add_every_other % 2 == 0)
-					parr_add_last(path, ((t_node_attr *)edge->u->attr)->org);
-				node = edge->u;
 				break ;
-			}
 			i++;
 		}
+		if (add_every_other++ % 2 == 0)
+		{
+			if (parr_add_last(path, ((t_node_attr *)edge->u->attr)->org) != 1)
+				lem_exit_error("ERROR");
+		}
+		node = edge->u;
 	}
 }
 
-static ssize_t	insert_path_to_array(t_parray *paths, t_parray *path_to_add)
+static void	insert_path_to_array(t_parray *paths, t_parray *path_to_add)
 {
 	size_t		i;
 	t_parray	*path;
@@ -39,10 +39,24 @@ static ssize_t	insert_path_to_array(t_parray *paths, t_parray *path_to_add)
 	{
 		path = parr_get(paths, i);
 		if (path->len > path_to_add->len)
-			return (parr_add(paths, path_to_add, i));
+			break ;
 		i++;
 	}
-	return (parr_add_last(paths, path_to_add));
+	if (parr_add(paths, path_to_add, i) != 1)
+		lem_exit_error("ERROR");
+}
+
+static t_parray	*init_path_array(size_t	arr_size)
+{
+	t_parray	*array;
+
+	array = (t_parray *)malloc(sizeof(t_parray));
+	if (array == NULL)
+		lem_exit_error("ERROR");
+	*array = parr_new(arr_size);
+	if (parr_null(array))
+		lem_exit_error("ERROR");
+	return (array);
 }
 
 t_parray	*lem_save_max_flow_paths(t_graph_node *s, t_graph_node *t,
@@ -51,24 +65,18 @@ t_parray	*lem_save_max_flow_paths(t_graph_node *s, t_graph_node *t,
 	t_parray		*paths;
 	t_parray		*path;
 	size_t			i;
-	t_graph_edge	*sink_edge;
+	t_graph_edge	*t_adj_edge;
 
-	paths = malloc(sizeof(t_parray));
-	if (paths == NULL)
-		return (NULL);
-	*paths = parr_new(max_flow);
-	if (parr_null(paths))
-		return (NULL);
+	paths = init_path_array(max_flow);
 	i = 0;
 	while (i < t->in.len)
 	{
-		sink_edge = parr_get(&t->in, i);
-		if (((t_edge_attr *)sink_edge->attr)->flow > 0)
+		t_adj_edge = parr_get(&t->in, i);
+		if (((t_edge_attr *)t_adj_edge->attr)->flow > 0)
 		{
-			path = malloc(sizeof(t_parray));
-			*path = parr_new(sizeof(t_graph_node *));
+			path = init_path_array(2);
 			parr_add_last(path, ((t_node_attr *)t->attr)->org);
-			save_flow_path(path, sink_edge->u, s);
+			save_flow_path(path, t_adj_edge->u, s);
 			insert_path_to_array(paths, path);
 		}
 		i++;

--- a/src/main.c
+++ b/src/main.c
@@ -1,12 +1,6 @@
 #include "lem_in.h"
 #include <stdlib.h>
 
-static int	error(char *msg)
-{
-	print_fd(2, "%s\n", msg);
-	return (1);
-}
-
 static ssize_t	free_string(void *str, size_t i)
 {
 	free(str);
@@ -28,25 +22,17 @@ static void	free_resources(t_lem *data, t_parray *input, t_parray *output)
 	}
 }
 
-static ssize_t	init_resources(t_lem *data, t_parray *input, t_parray *output)
+static void	init_resources(t_lem *data, t_parray *input, t_parray *output)
 {
 	*data = lem_init_data();
 	if (graph_null(&data->graph))
-		return (-1);
+		lem_exit_error("ERROR");
 	*input = parr_new(1);
 	if (parr_null(input))
-	{
-		lem_free_graph(&data->graph);
-		return (-1);
-	}
+		lem_exit_error("ERROR");
 	*output = parr_new(1);
 	if (parr_null(output))
-	{
-		lem_free_graph(&data->graph);
-		parr_free(input);
-		return (-1);
-	}
-	return (1);
+		lem_exit_error("ERROR");
 }
 
 int	main(void)
@@ -55,21 +41,18 @@ int	main(void)
 	t_parray	input;
 	t_parray	output;
 
-	if (!init_resources(&data, &input, &output))
-		return (error("Error"));
+	init_resources(&data, &input, &output);
 	if (lem_parse_input(&data, &input) != 1)
 	{
 		free_resources(&data, &input, &output);
-		return (error("Error on parsing input"));
+		lem_exit_error("Error on parsing input");
 	}
 	if (lem_process_graph(&output, &data) != 1)
 	{
 		free_resources(&data, &input, &output);
-		return (error("Error on processing graph"));
+		lem_exit_error("Error on processing graph");
 	}
-	parr_iter(&input, lem_print_string);
-	print("\n");
-	parr_iter(&output, lem_print_string);
+	lem_print_result(&input, &output);
 	free_resources(&data, &input, &output);
 	return (0);
 }


### PR DESCRIPTION
Now, all calls to ``malloc`` or functions in core that may result in malloc failure are checked and if they have failed, ``lem_exit_error`` is called with the error message "ERROR". 