### PR TITLE
modify initializing node attributes

### DIFF
--- a/src/lem_init_node_attributes.c
+++ b/src/lem_init_node_attributes.c
@@ -1,7 +1,8 @@
 #include "lem_in.h"
 
 /*
- *	Initialize node attributes.
+ *	Initialize node attributes. Name is assumed to have been dynamically
+ *	allocated.
  */
 
 t_node_attr	*lem_init_node_attr(
@@ -11,15 +12,12 @@ t_node_attr	*lem_init_node_attr(
 {
 	t_node_attr	*attr;
 
+	if (name == NULL)
+		return (NULL);
 	attr = (t_node_attr *)malloc(sizeof(t_node_attr));
 	if (attr == NULL)
 		return (NULL);
-	attr->name = s_dup(name);
-	if (attr->name == NULL)
-	{
-		free(attr);
-		return (NULL);
-	}
+	attr->name = name;
 	attr->value = 0;
 	attr->coordinates = coords;
 	attr->org = org;

--- a/src/lem_parse_room.c
+++ b/src/lem_parse_room.c
@@ -32,12 +32,14 @@ static int	validate_coordinates(char *line, t_coordinates *coordinates)
  *	save the room key in the data struct.
  */
 
-static void	update_lem_data(t_lem *data, char *key, enum e_line_type type)
+static void	update_lem_data_and_type(t_lem *data, char *key,
+	enum e_line_type *type)
 {
-	if (type == ROOM_SRC)
+	if (*type == ROOM_SRC)
 		data->s_key = key;
 	else
 		data->t_key = key;
+	*type = ROOM;
 }
 
 /*
@@ -60,19 +62,17 @@ int	lem_parse_room(t_lem *data, char *line, enum e_line_type *type)
 		*type = LINK;
 		return (lem_parse_link(data, line));
 	}
-	*ptr = '\0';
 	if (!validate_coordinates(ptr + 1, &coordinates))
 		return (-1);
-	attr = lem_init_node_attr(line, coordinates, NULL);
+	attr = lem_init_node_attr(s_sub(line, 0, (uint64_t)(ptr - line)),
+			coordinates, NULL);
 	if (!attr || graph_add_node(&data->graph, attr->name, attr) != 1)
 	{
 		free(attr->name);
 		free(attr);
 		return (-1);
 	}
-	*ptr = ' ';
 	if (*type == ROOM_SRC || *type == ROOM_SINK)
-		update_lem_data(data, attr->name, *type);
-	*type = ROOM;
+		update_lem_data_and_type(data, attr->name, type);
 	return (1);
 }

--- a/src/lem_transform_vertex_disjoint.c
+++ b/src/lem_transform_vertex_disjoint.c
@@ -82,20 +82,17 @@ static char	*split_node(void *parse_dst, void *data, const char *key)
 	t_graph_node	*node;
 	t_node_attr		*in_node_attr;
 	t_node_attr		*out_node_attr;
-	char			*new_key;
 
 	graph = parse_dst;
 	node = data;
-	new_key = s_join(key, "_in");
-	in_node_attr = lem_init_node_attr(new_key, (t_coordinates){0, 0}, node);
-	if (!new_key || !in_node_attr)
+	in_node_attr = lem_init_node_attr(s_join(key, "_in"),
+			(t_coordinates){0, 0}, node);
+	if (!in_node_attr)
 		lem_exit_error("ERROR");
-	free(new_key);
-	new_key = s_join(key, "_out");
-	out_node_attr = lem_init_node_attr(new_key, (t_coordinates){0, 0}, node);
-	if (!new_key || !out_node_attr)
+	out_node_attr = lem_init_node_attr(s_join(key, "_out"),
+			(t_coordinates){0, 0}, node);
+	if (!out_node_attr)
 		lem_exit_error("ERROR");
-	free(new_key);
 	if (graph_add_node(graph, in_node_attr->name, in_node_attr) != 1
 		|| graph_add_node(graph, out_node_attr->name, out_node_attr) != 1)
 		lem_exit_error("ERROR");


### PR DESCRIPTION
Allocate memory for the name before calling ``init_node_attr``. Just for the sake of shortening the code in ``lem_parse_room`` and ``lem_transform_vertex_disjoint``.